### PR TITLE
Remove the --with-harfbuzz=no configure flag.

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -4,7 +4,6 @@ CONFIGURE_FLAGS := \
     --without-zlib \
     --disable-shared \
     --with-pic=yes \
-    --with-harfbuzz=no \
     $(NULL)
 
 


### PR DESCRIPTION
It’s apparently not supported in this version, but only makes the build fail on some environments?

http://logs.glob.uno/?c=mozilla%23servo#c134890
