### PR TITLE
Be more tolerant of whitespace in compiler

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -29,7 +29,7 @@ SRC_DIR = $(shell pwd)
 
 .PHONY: all
 all:
-	cd $(OUT_DIR) && CC=$(CC) AR=$(AR) $(SRC_DIR)/configure $(strip $(CONFIGURE_FLAGS))
+	cd $(OUT_DIR) && CC="$(CC)" AR="$(AR)" $(SRC_DIR)/configure $(strip $(CONFIGURE_FLAGS))
 	cd $(OUT_DIR) && make -j4
 	cp $(OUT_DIR)/.libs/libfreetype.a $(OUT_DIR)
 	cp -R include $(OUT_DIR)


### PR DESCRIPTION
One way to use 'ccache' is to invoke the compiler as "ccache gcc".
There might be other situations where the compiler (or even archiver)
contain white space: quote the variable.

Fixes https://github.com/servo/servo/issues/4631
