### PR TITLE
Allow using MAKE env var instead of "make".

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,8 @@ use std::process::{Command, Stdio};
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let result = Command::new("make")
+    let make = env::var("MAKE").unwrap_or("make".to_string());
+    let result = Command::new(make)
         .args(&["-f", "makefile.cargo"])
         .status()
         .unwrap();


### PR DESCRIPTION
This allows use of an alternative name for GNU make, e.g. "gmake".