### PR TITLE
Disable initial values set by `make`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let make = env::var("MAKE").unwrap_or("make".to_string());
     let result = Command::new(make)
-        .args(&["-f", "makefile.cargo"])
+        .args(&["-R", "-f", "makefile.cargo"])
         .status()
         .unwrap();
     assert!(result.success());


### PR DESCRIPTION
This fixes cross compilation issues, so freetype now builds correctly for both Android and ARM.
(See servo/servo#6537)

Part of servo/servo#6327.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/14)
<!-- Reviewable:end -->
