### PR TITLE
win32 build fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ build = "build.rs"
 [lib]
 name = "freetype_sys"
 path = "lib.rs"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate pkg_config;
+
 use std::env;
 use std::process::Command;
 
 fn main() {
+    if !env::var("TARGET").unwrap().contains("eabi") &&
+        pkg_config::Config::new().atleast_version("16.0.10").find("freetype2").is_ok()
+    {
+        return;
+    }
+
     let make = env::var("MAKE").unwrap_or("make".to_string());
     let result = Command::new(make)
         .args(&["-R", "-f", "makefile.cargo"])


### PR DESCRIPTION
This uses pkg-config to see if the system already has freetype2 built, and if so just uses it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/17)
<!-- Reviewable:end -->
