### PR TITLE
Always build Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-freetype-sys"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["The FreeType Team"]
 links = "freetype"
 license = "FTL / GPL-2.0"

--- a/build.rs
+++ b/build.rs
@@ -14,13 +14,9 @@ fn main() {
         return
     }
 
-    let dst = Config::new("freetype2").build();
+    let dst = Config::new("freetype2").profile("Release").build();
     let out_dir = env::var("OUT_DIR").unwrap();
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
-    if env::var("PROFILE").unwrap().contains("debug") {
-        println!("cargo:rustc-link-lib=static=freetyped");
-    } else {
-        println!("cargo:rustc-link-lib=static=freetype");
-    }
+    println!("cargo:rustc-link-lib=static=freetype");
     println!("cargo:outdir={}", out_dir);
 }


### PR DESCRIPTION
On MSVC, the cmake crate selects Release always, even when the PROFILE might indicate debug.  In order to not have to replicate that logic here, just always build Release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/22)
<!-- Reviewable:end -->
