### PR TITLE
Do not use pkg-config on Android

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,9 @@ use cmake::Config;
 use std::env;
 
 fn main() {
-    if !env::var("TARGET").unwrap().contains("eabi") &&
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("eabi") &&
+        !target.contains("android") &&
         pkg_config::Config::new().atleast_version("18.5.12").find("freetype2").is_ok() {
         return
     }


### PR DESCRIPTION
Similar to https://github.com/servo/libfontconfig/pull/37 and https://github.com/servo/libexpat/pull/22, using pkg-config after enabling PKG_CONFIG_ALLOW_CROSS in Servo, breaks the build. So I'd like to leave things as they currently are and continue building this lib for Android.

I only noticed this when building for x86 because we were already special casing targets containing the `eabi` string (i.e. *androideabi).

See [here](https://github.com/servo/libexpat/pull/22#issuecomment-421924353) for a more detailed explanation for this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/25)
<!-- Reviewable:end -->
