### PR TITLE
Add an env var for cmake generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-freetype-sys"
-version = "4.0.4"
+version = "4.0.5"
 authors = ["The FreeType Team"]
 links = "freetype"
 license = "FTL / GPL-2.0"

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,11 @@ fn main() {
         return
     }
 
-    let dst = Config::new("freetype2")
+    let mut config = Config::new("freetype2");
+    if let Ok(s) = env::var("FREETYPE_CMAKE_GENERATOR") {
+        config.generator(s);
+    }
+    let dst = config
         .define("WITH_BZip2", "OFF")
         .define("WITH_HarfBuzz", "OFF")
         .define("WITH_PNG", "OFF")


### PR DESCRIPTION
Some discussion in https://github.com/alexcrichton/cmake-rs/issues/66, it's not clear to me what the best solution is yet but I'm putting up this patch here anyway. It certainly solves my issue and unblocks me, so please feel free to merge this if it's acceptable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/28)
<!-- Reviewable:end -->
