### PR TITLE
Add "build-native-freetype" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,9 @@ build = "build.rs"
 name = "freetype_sys"
 
 [build-dependencies]
-pkg-config = "0.3"
-cmake = "0.1"
+pkg-config = { version = "0.3", optional = true }
+cmake = { version = "0.1", optional = true }
+
+[features]
+default = ["build-native-freetype"]
+build-native-freetype = ["pkg-config", "cmake"]

--- a/build.rs
+++ b/build.rs
@@ -2,13 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(feature = "build-native-freetype")]
 extern crate cmake;
+#[cfg(feature = "build-native-freetype")]
 extern crate pkg_config;
 
-use cmake::Config;
-use std::env;
-
+#[cfg(feature = "build-native-freetype")]
 fn main() {
+    use cmake::Config;
+    use std::env;
+
     let target = env::var("TARGET").unwrap();
     if !target.contains("eabi") &&
         !target.contains("android") &&
@@ -32,3 +35,6 @@ fn main() {
     println!("cargo:rustc-link-lib=static=freetype");
     println!("cargo:outdir={}", out_dir);
 }
+
+#[cfg(not(feature = "build-native-freetype"))]
+fn main() {}


### PR DESCRIPTION
- Declare a default "build-native-freetype" feature.
- Make the pkg-config and cmake build-dependencies optional.
- Make build.rs a no-op if "build-native-freetype" is disabled.

These changes allow the library to be used in projects where the native freetype library is built separately, and where cmake and pkg-config are not supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libfreetype2/30)
<!-- Reviewable:end -->
